### PR TITLE
8 get user consent on writing config file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports:
     colorspace,
-    config,
     curl,
     ggplot2,
     jsonlite,
@@ -25,6 +24,7 @@ Imports:
     spacesXYZ,
     sysfonts (>= 0.8.8),
     showtext,
-    tableHTML
+    tableHTML,
+    yaml
 Depends: 
     R (>= 2.10)

--- a/R/load_configs.R
+++ b/R/load_configs.R
@@ -16,20 +16,18 @@
 #' the charts in this project will have a cohesive style without you having to
 #' specify this style across the multiple files in your project.
 #'
-#' @param config Within `file`, which configuration to use. Defaults to
-#'   `"default"`. Useful if multiple versions of the same theme are stored in
-#'   one configuration file.
 #' @param file A .yml file. The configuration file to load. Should be created by
 #'   [save_configs()]. Defaults to `chameleon.yml`.
 #'
 #' @export
-load_configs <- function(config = "default",file="chameleon.yml") {
+load_configs <- function(file="chameleon.yml") {
   if (file.exists(file)){
-    configs <- config::get(config = config,file=file)
+    configs <- yaml::read_yaml(file)
     rlang::exec("edit_the_main_palette",!!!configs$main_palette)
     rlang::exec("edit_the_accent_palette",!!!configs$accent_palette)
     rlang::exec("edit_the_fonts",!!!configs$fonts)
     rlang::exec("edit_the_theme",!!!configs$theme)
+    message("Loading configurations stored in \"",file,"\".")
   } else if (file!="chameleon.yml"){
     message(paste0("File \"",file,"\" not found. Resorting to existing. configs."))
   } else{

--- a/R/save_configs.R
+++ b/R/save_configs.R
@@ -33,18 +33,17 @@ save_configs <- function(file="chameleon.yml",overwrite=FALSE){
   yml_exists <- file.exists(file)
 
   if (!yml_exists){
-    yaml::write_yaml(list(ggchameleon_configs=as.list(the)),file)
+    yaml::write_yaml(as.list(the),file)
     message("Configurations saved to \"",file,"\".")
   } else if (!overwrite){
     parent_dir <- dirname(file)
-    parent_dir <- gsub("^\\.$","",parent_dir)
     file_name <- tools::file_path_sans_ext(basename(file)) |> paste0("_")
     new_file <- tempfile(file_name,tmpdir = parent_dir,fileext = '.yml')
-    yaml::write_yaml(list(ggchameleon_configs=as.list(the)),new_file)
+    yaml::write_yaml(as.list(the),new_file)
     message(paste0("The file \"",file,"\" exists, saving as: \"", new_file,
                    "\".\nConsider renaming this to something more relevant."))
   } else {
-    yaml::write_yaml(list(ggchameleon_configs=as.list(the)),file)
+    yaml::write_yaml(as.list(the),file)
     message("Configurations overwritten at \"",file,"\".")
   }
 }

--- a/R/save_configs.R
+++ b/R/save_configs.R
@@ -32,18 +32,22 @@ save_configs <- function(file="chameleon.yml",overwrite=FALSE){
 
   yml_exists <- file.exists(file)
 
+  # We don't care about what theme the user had prior
+  # to using ggchameleon
+  to_write <- as.list(the)[names(the)!='old_theme']
+
   if (!yml_exists){
-    yaml::write_yaml(as.list(the),file)
+    yaml::write_yaml(to_write,file)
     message("Configurations saved to \"",file,"\".")
   } else if (!overwrite){
     parent_dir <- dirname(file)
     file_name <- tools::file_path_sans_ext(basename(file)) |> paste0("_")
     new_file <- tempfile(file_name,tmpdir = parent_dir,fileext = '.yml')
-    yaml::write_yaml(as.list(the),new_file)
+    yaml::write_yaml(to_write,new_file)
     message(paste0("The file \"",file,"\" exists, saving as: \"", new_file,
                    "\".\nConsider renaming this to something more relevant."))
   } else {
-    yaml::write_yaml(as.list(the),file)
+    yaml::write_yaml(to_write,file)
     message("Configurations overwritten at \"",file,"\".")
   }
 }

--- a/R/save_configs.R
+++ b/R/save_configs.R
@@ -15,6 +15,9 @@
 #' ggplot2, it will automatically start using whatever you have saved.
 #'
 #' @param file A file path ending in `".yml"`. Defaults to `"chameleon.yml"`.
+#' @param overwrite A boolean. Whether or not to overwrite `file` if it exists.
+#'   Defaults to `FALSE`. When `FALSE`, `file` will have random characters
+#'   appended to the end of the name to disambiguate.
 #'
 #' @examples
 #'
@@ -25,20 +28,23 @@
 #' save_configs("my_different_configs.yml")
 #'
 #' @export
-save_configs <- function(file="chameleon.yml"){
-  if (!requireNamespace("config", quietly = TRUE)) {
-    stop(
-      "Package \"config\" must be installed to use this function.",
-      call. = FALSE
-    )
-  }
+save_configs <- function(file="chameleon.yml",overwrite=FALSE){
 
-  while (file.exists(file)){
-    new_file <- tempfile("chameleon_",tmpdir = "",fileext = ".yml")
-    new_file <- substr(new_file,2,nchar(new_file))
-    message(paste0("\"",file,"\" exists, saving as: \"", new_file,
-                   "\"\nConsider Renaming the File to Something More Relevant"))
-    file <- new_file
+  yml_exists <- file.exists(file)
+
+  if (!yml_exists){
+    yaml::write_yaml(list(ggchameleon_configs=as.list(the)),file)
+    message("Configurations saved to \"",file,"\".")
+  } else if (!overwrite){
+    parent_dir <- dirname(file)
+    parent_dir <- gsub("^\\.$","",parent_dir)
+    file_name <- tools::file_path_sans_ext(basename(file)) |> paste0("_")
+    new_file <- tempfile(file_name,tmpdir = parent_dir,fileext = '.yml')
+    yaml::write_yaml(list(ggchameleon_configs=as.list(the)),new_file)
+    message(paste0("The file \"",file,"\" exists, saving as: \"", new_file,
+                   "\".\nConsider renaming this to something more relevant."))
+  } else {
+    yaml::write_yaml(list(ggchameleon_configs=as.list(the)),file)
+    message("Configurations overwritten at \"",file,"\".")
   }
-  yaml::write_yaml(list(default = as.list(the)),file)
 }

--- a/man/load_configs.Rd
+++ b/man/load_configs.Rd
@@ -4,13 +4,9 @@
 \alias{load_configs}
 \title{Load stylistic configurations from a file}
 \usage{
-load_configs(config = "default", file = "chameleon.yml")
+load_configs(file = "chameleon.yml")
 }
 \arguments{
-\item{config}{Within \code{file}, which configuration to use. Defaults to
-\code{"default"}. Useful if multiple versions of the same theme are stored in
-one configuration file.}
-
 \item{file}{A .yml file. The configuration file to load. Should be created by
 \code{\link[=save_configs]{save_configs()}}. Defaults to \code{chameleon.yml}.}
 }

--- a/man/save_configs.Rd
+++ b/man/save_configs.Rd
@@ -4,10 +4,14 @@
 \alias{save_configs}
 \title{Save stylistic configurations to a file for later use}
 \usage{
-save_configs(file = "chameleon.yml")
+save_configs(file = "chameleon.yml", overwrite = FALSE)
 }
 \arguments{
 \item{file}{A file path ending in \code{".yml"}. Defaults to \code{"chameleon.yml"}.}
+
+\item{overwrite}{A boolean. Whether or not to overwrite \code{file} if it exists.
+Defaults to \code{FALSE}. When \code{FALSE}, \code{file} will have random characters
+appended to the end of the name to disambiguate.}
 }
 \description{
 If you are happy with your current chart style, and you wish to use it again


### PR DESCRIPTION
Closes #8.

This was a bit of a rabbit hole, but i think it introduces some important improvements.

Namely, we opted not to actually get consent (running a `save` function is implicitly getting consent through its use), but we do message the user that they have saved their configs. 

We transitioned away from the `config` package to handle the generation of the config yaml files. We now use the simpler `yaml` package (which `config` was calling under the hood anyway). This removed the confusing `config` option in the `load_configs` function.