### PR TITLE
73 reset geoms and scales onunload

### DIFF
--- a/R/save_configs.R
+++ b/R/save_configs.R
@@ -37,7 +37,7 @@ save_configs <- function(file="chameleon.yml",overwrite=FALSE){
 
   # We don't care about what theme the user had prior
   # to using ggchameleon
-  to_write <- as.list(the)[names(the)!='old_theme']
+  to_write <- as.list(the)[!names(the)%in%c('old_theme','old_geoms','old_scales')]
 
   # Convert gg theme to yaml friendly list
   to_write[['theme']] <- theme_to_list(to_write[['theme']])

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,26 @@
 .onLoad <- function(libname, pkgname) {
+  # Capture Current Options Before Loading:
   the$old_theme <- ggplot2::theme_get()
+  scales_to_check <-  c(
+    "ggplot2.discrete.colour",
+    "ggplot2.continuous.colour",
+    "ggplot2.binned.colour",
+    "ggplot2.discrete.fill",
+    "ggplot2.continuous.fill",
+    "ggplot2.binned.fill",
+    "ggplot2.ordinal.colour",
+    "ggplot2.ordinal.fill"
+  )
+  the$old_scales <- rlang::exec(options, !!!scales_to_check)
+  geom_names <- getNamespaceExports("ggplot2")
+  geom_names <- geom_names[grepl("^Geom",geom_names)]
+  the$old_geoms <-
+    lapply(geom_names,
+           function(x) {
+             get(x, envir = getNamespace("ggplot2"))$default_aes
+           })
+  names(the$old_geoms) <- geom_names
+
   showtext::showtext_auto()
   load_configs()
   refresh_theming()
@@ -11,4 +32,10 @@
 
 .onUnload <- function(libname,pkgname) {
   ggplot2::theme_set(the$old_theme)
+  rlang::exec(options,!!!the$old_scales)
+  mapply(function(n,x){
+    geom_name <- gsub("^Geom","",n)
+    ggplot2::update_geom_defaults(geom_name,x)
+  },
+  names(the$old_geoms),the$old_geoms)
 }

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,0 +1,48 @@
+test_that(".onAttach captures theme", {
+  expect_equal(the$old_theme, ggplot2::theme_gray())
+})
+
+test_that(".onAttach captures geoms", {
+  expect_equal(the$old_geoms$GeomPoint,
+               ggplot2::aes(
+                 shape = 19,
+                 colour = "black",
+                 size = 1.5,
+                 fill = NA,
+                 alpha = NA,
+                 stroke = 0.5
+               ))
+})
+
+test_that(".onAttach captures scales", {
+  expect_null(the$old_scales$ggplot2.discrete.colour)
+})
+
+test_that(".onUnload resets theme",{
+  cur_theme <- ggplot2::theme_get()
+  edit_the_theme(legend.position="bottom")
+  .onUnload()
+  expect_equal(
+    ggplot2::theme_get()$legend.position,
+    "right"
+  )
+  edit_the_theme(cur_theme)
+})
+
+test_that(".onUnload resets geoms",{
+  .onUnload()
+  expect_equal(
+    GeomBar$default_aes$fill,
+    "grey35"
+  )
+  refresh_theming()
+})
+
+test_that(".onUnload resets scales",{
+  .onUnload()
+  expect_equal(
+    options("ggplot2.continuous.fill"),
+    list("ggplot2.continuous.fill"=NULL)
+  )
+  refresh_theming()
+})


### PR DESCRIPTION
- 76241b066c8250b43603acad1aec779cdc027221 is a bit of a hack because there's no good way to access all of the `Geom`s at once, so we have to manually search for them using `getNamespaceExports`. But once we've done that, we save the `Geom`s and `scale` to `the$old_geoms` and `the$old_scales` respectively.
-  0fcafc8e57505e808dbfc42e3ace44b27b2f1af4 makes sure that when we save a configuration file, we're not accidentally also saving the incoming parameters